### PR TITLE
Suggestion/Fix:  Gap Not Maintained

### DIFF
--- a/src/less/memo-editor.less
+++ b/src/less/memo-editor.less
@@ -7,6 +7,7 @@
   height: auto;
   background-color: white;
   padding: 16px;
+  margin-bottom: 8px;
   border-radius: 8px;
   border: 2px solid @bg-gray;
 
@@ -57,6 +58,7 @@
   height: auto;
   background-color: rgb(59, 59, 59);
   padding: 16px;
+  margin-bottom: 8px;
   border-radius: 8px;
   border: 2px solid @bg-dark-gray;
 

--- a/src/less/memo.less
+++ b/src/less/memo.less
@@ -6,9 +6,12 @@
   width: 100%;
   padding: 12px 18px;
   background-color: rgb(255, 255, 255);
-  margin-top: 8px;
   border-radius: 8px;
   border: 1px solid transparent;
+
+  &:not(:first-child) {
+    margin-top: 8px;
+  }
 
   &:hover {
     border-color: @bg-gray;
@@ -174,9 +177,12 @@
   width: 100%;
   padding: 12px 18px;
   background-color: #303030;
-  margin-top: 8px;
   border-radius: 8px;
   border: 1px solid transparent;
+
+  &:not(:first-child) {
+    margin-top: 8px;
+  }
 
   &:hover {
     border-color: @bg-dark-gray;

--- a/styles.css
+++ b/styles.css
@@ -490,6 +490,7 @@
   height: auto;
   background-color: white;
   padding: 16px;
+  margin-bottom: 8px;
   border-radius: 8px;
   border: 2px solid #e4e4e4;
 }
@@ -539,6 +540,7 @@
   height: auto;
   background-color: #3b3b3b;
   padding: 16px;
+  margin-bottom: 8px;
   border-radius: 8px;
   border: 2px solid #353535;
 }
@@ -3449,9 +3451,11 @@ div[data-type='memos_view'] .image-container > img {
   width: 100%;
   padding: 12px 18px;
   background-color: #ffffff;
-  margin-top: 8px;
   border-radius: 8px;
   border: 1px solid transparent;
+}
+.theme-light div[data-type='memos_view'] .memo-wrapper:not(:first-child) {
+  margin-top: 8px;
 }
 .theme-light div[data-type='memos_view'] .memo-wrapper:hover {
   border-color: #e4e4e4;
@@ -3632,9 +3636,11 @@ div[data-type='memos_view'] .image-container > img {
   width: 100%;
   padding: 12px 18px;
   background-color: #303030;
-  margin-top: 8px;
   border-radius: 8px;
   border: 1px solid transparent;
+}
+.theme-dark div[data-type='memos_view'] .memo-wrapper:not(:first-child) {
+  margin-top: 8px;
 }
 .theme-dark div[data-type='memos_view'] .memo-wrapper:hover {
   border-color: #353535;


### PR DESCRIPTION
## Issue: Gap Not Maintained

I don't know if it is an UI choice, but the gap between the 'memo-editor-wrapper' and the 'memolist-wrapper' is not maintained when scrolling.

![gapSuggestion](https://user-images.githubusercontent.com/69484045/151628191-0d1fafb1-7578-4d09-9909-619e41711258.png)

## Solution

- Added 'margin-bottom: 8px' to the 'memo-editor-wrapper' for both the Dark & Light Themes.

## Dealing with the bottom margin from the 'memo-editor-wrapper' and the top-margin from the 'memo-wrapper'

- Added the pseudo classes ':not(:first-child)' so the first/top memo didn't have a margin-top applied, maintaining the original spacing between the memos and the editor.

## Suggestion

I tried messing with the gap property a bit, due the containers being essentially flex containers, but when removing the respective containers margins or paddings it removed those same properties on other elements. Might work a bit more on that if it's preferable though.
