### PR TITLE
Fix: Query Filter Spacing

### DIFF
--- a/src/less/home.less
+++ b/src/less/home.less
@@ -24,6 +24,7 @@ div[data-type='memos_view'] #page-wrapper {
     padding-left: 10px;
     width: 600px;
     height: 100%;
+    gap: 8px;
     // overflow-y: hidden;
   }
 
@@ -35,6 +36,7 @@ div[data-type='memos_view'] #page-wrapper {
     height: 100%;
     overflow-y: hidden;
     padding-left: 34px;
+    gap: 8px;
   }
 }
 

--- a/src/less/memo-editor.less
+++ b/src/less/memo-editor.less
@@ -7,7 +7,7 @@
   height: auto;
   background-color: white;
   padding: 16px;
-  margin-bottom: 8px;
+
   border-radius: 8px;
   border: 2px solid @bg-gray;
 
@@ -41,7 +41,6 @@
     width: calc(100% - 24px);
     margin: auto;
     margin-right: 16px;
-    margin-bottom: 8px;
   }
 
   .theme-light img.memo-show-editor-button {
@@ -58,7 +57,7 @@
   height: auto;
   background-color: rgb(59, 59, 59);
   padding: 16px;
-  margin-bottom: 8px;
+
   border-radius: 8px;
   border: 2px solid @bg-dark-gray;
 
@@ -92,7 +91,6 @@
     width: calc(100% - 24px);
     margin: auto;
     margin-right: 16px;
-    margin-bottom: 8px;
   }
 
   .theme-dark img.memo-show-editor-button {

--- a/src/less/memo-filter.less
+++ b/src/less/memo-filter.less
@@ -5,7 +5,7 @@
   width: 100%;
   flex-wrap: wrap;
   padding: 4px 12px;
-  padding-bottom: 12px;
+  padding-bottom: 4px;
   font-size: 13px;
   line-height: 1.8;
 
@@ -69,7 +69,7 @@
   width: 100%;
   flex-wrap: wrap;
   padding: 4px 12px;
-  padding-bottom: 12px;
+  padding-bottom: 4px;
   font-size: 13px;
   line-height: 1.8;
 

--- a/src/less/memo-filter.less
+++ b/src/less/memo-filter.less
@@ -4,8 +4,8 @@
   .flex(row, space-between, center);
   width: 100%;
   flex-wrap: wrap;
-  padding: 12px 12px;
-  padding-bottom: 4px;
+  padding: 4px 12px;
+  padding-bottom: 12px;
   font-size: 13px;
   line-height: 1.8;
 
@@ -17,7 +17,7 @@
       margin-left: -6px;
       margin-right: 3px;
     }
-  
+
     > .filter-item-container {
       padding: 2px 8px;
       padding-left: 4px;
@@ -29,11 +29,11 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-  
+
       > .icon-text {
         letter-spacing: 2px;
       }
-  
+
       &:hover {
         text-decoration: line-through;
       }
@@ -53,7 +53,7 @@
 
     &:hover {
       opacity: 0.8;
-      filter:contrast(1) brightness(1) invert(0.5);
+      filter: contrast(1) brightness(1) invert(0.5);
     }
   }
 }
@@ -68,12 +68,12 @@
   .flex(row, space-between, center);
   width: 100%;
   flex-wrap: wrap;
-  padding: 12px 12px;
-  padding-bottom: 4px;
+  padding: 4px 12px;
+  padding-bottom: 12px;
   font-size: 13px;
   line-height: 1.8;
 
-  > .filter-query{
+  > .filter-query {
     .flex(row, flex-start, flex-start);
 
     > .tip-text {
@@ -82,7 +82,7 @@
       margin-right: 3px;
       color: @text-dark-black;
     }
-  
+
     > .filter-item-container {
       padding: 2px 8px;
       padding-left: 4px;
@@ -94,11 +94,11 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-  
+
       > .icon-text {
         letter-spacing: 2px;
       }
-  
+
       &:hover {
         text-decoration: line-through;
       }
@@ -118,7 +118,7 @@
 
     &:hover {
       opacity: 0.8;
-      filter:contrast(1) brightness(1) invert(0.9);
+      filter: contrast(1) brightness(1) invert(0.9);
     }
   }
 }

--- a/src/less/memo.less
+++ b/src/less/memo.less
@@ -9,10 +9,6 @@
   border-radius: 8px;
   border: 1px solid transparent;
 
-  &:not(:first-child) {
-    margin-top: 8px;
-  }
-
   &:hover {
     border-color: @bg-gray;
   }
@@ -179,10 +175,6 @@
   background-color: #303030;
   border-radius: 8px;
   border: 1px solid transparent;
-
-  &:not(:first-child) {
-    margin-top: 8px;
-  }
 
   &:hover {
     border-color: @bg-dark-gray;

--- a/src/less/memolist.less
+++ b/src/less/memolist.less
@@ -5,6 +5,7 @@
   flex-grow: 1;
   width: 100%;
   overflow-y: scroll;
+  gap: 8px;
   .hide-scroll-bar();
 
   > .status-text-container {
@@ -43,6 +44,7 @@
   flex-grow: 1;
   width: 100%;
   overflow-y: scroll;
+  gap: 8px;
   .hide-scroll-bar();
 
   > .status-text-container {

--- a/src/less/memos-header.less
+++ b/src/less/memos-header.less
@@ -7,7 +7,6 @@ div[data-type='memos_view'] .memos-header-container {
   height: 40px;
   flex-wrap: nowrap;
   margin-top: 16px;
-  margin-bottom: 8px;
   flex-shrink: 0;
 
   > .title-text {
@@ -76,7 +75,6 @@ div[data-type='memos_view'] .memos-header-container {
   height: 40px;
   flex-wrap: nowrap;
   margin-top: 16px;
-  margin-bottom: 8px;
   flex-shrink: 0;
 
   > .title-text {

--- a/styles.css
+++ b/styles.css
@@ -1629,8 +1629,8 @@ div[data-type='memos_view'] .memos-header-container > .btns-container {
   align-items: center;
   width: 100%;
   flex-wrap: wrap;
-  padding: 12px 12px;
-  padding-bottom: 4px;
+  padding: 4px 12px;
+  padding-bottom: 12px;
   font-size: 13px;
   line-height: 1.8;
 }
@@ -1686,8 +1686,8 @@ div[data-type='memos_view'] .memos-header-container > .btns-container {
   align-items: center;
   width: 100%;
   flex-wrap: wrap;
-  padding: 12px 12px;
-  padding-bottom: 4px;
+  padding: 4px 12px;
+  padding-bottom: 12px;
   font-size: 13px;
   line-height: 1.8;
 }

--- a/styles.css
+++ b/styles.css
@@ -490,7 +490,6 @@
   height: auto;
   background-color: white;
   padding: 16px;
-  margin-bottom: 8px;
   border-radius: 8px;
   border: 2px solid #e4e4e4;
 }
@@ -522,7 +521,6 @@
     width: calc(100% - 24px);
     margin: auto;
     margin-right: 16px;
-    margin-bottom: 8px;
   }
   .theme-light img.memo-show-editor-button {
     position: fixed;
@@ -540,7 +538,6 @@
   height: auto;
   background-color: #3b3b3b;
   padding: 16px;
-  margin-bottom: 8px;
   border-radius: 8px;
   border: 2px solid #353535;
 }
@@ -572,7 +569,6 @@
     width: calc(100% - 24px);
     margin: auto;
     margin-right: 16px;
-    margin-bottom: 8px;
   }
   .theme-dark img.memo-show-editor-button {
     position: fixed;
@@ -1441,7 +1437,6 @@ div[data-type='memos_view'] .memos-header-container {
   height: 40px;
   flex-wrap: nowrap;
   margin-top: 16px;
-  margin-bottom: 8px;
   flex-shrink: 0;
 }
 div[data-type='memos_view'] .section-header-container > .title-text,
@@ -1522,7 +1517,6 @@ div[data-type='memos_view'] .memos-header-container > .btns-container {
   height: 40px;
   flex-wrap: nowrap;
   margin-top: 16px;
-  margin-bottom: 8px;
   flex-shrink: 0;
 }
 .theme-dark div[data-type='memos_view'] .section-header-container > .title-text,
@@ -1630,7 +1624,7 @@ div[data-type='memos_view'] .memos-header-container > .btns-container {
   width: 100%;
   flex-wrap: wrap;
   padding: 4px 12px;
-  padding-bottom: 12px;
+  padding-bottom: 4px;
   font-size: 13px;
   line-height: 1.8;
 }
@@ -1687,7 +1681,7 @@ div[data-type='memos_view'] .memos-header-container > .btns-container {
   width: 100%;
   flex-wrap: wrap;
   padding: 4px 12px;
-  padding-bottom: 12px;
+  padding-bottom: 4px;
   font-size: 13px;
   line-height: 1.8;
 }
@@ -3454,9 +3448,6 @@ div[data-type='memos_view'] .image-container > img {
   border-radius: 8px;
   border: 1px solid transparent;
 }
-.theme-light div[data-type='memos_view'] .memo-wrapper:not(:first-child) {
-  margin-top: 8px;
-}
 .theme-light div[data-type='memos_view'] .memo-wrapper:hover {
   border-color: #e4e4e4;
 }
@@ -3638,9 +3629,6 @@ div[data-type='memos_view'] .image-container > img {
   background-color: #303030;
   border-radius: 8px;
   border: 1px solid transparent;
-}
-.theme-dark div[data-type='memos_view'] .memo-wrapper:not(:first-child) {
-  margin-top: 8px;
 }
 .theme-dark div[data-type='memos_view'] .memo-wrapper:hover {
   border-color: #353535;
@@ -3845,6 +3833,7 @@ div[data-type='memos_view'] .image-container > img {
   flex-grow: 1;
   width: 100%;
   overflow-y: scroll;
+  gap: 8px;
   scrollbar-width: none;
 }
 .theme-light div[data-type='memos_view'] .memolist-wrapper::-webkit-scrollbar {
@@ -3899,6 +3888,7 @@ div[data-type='memos_view'] .image-container > img {
   flex-grow: 1;
   width: 100%;
   overflow-y: scroll;
+  gap: 8px;
   scrollbar-width: none;
 }
 .theme-dark div[data-type='memos_view'] .memolist-wrapper::-webkit-scrollbar {
@@ -3978,7 +3968,6 @@ div[data-type='memos_view'] .memos-header-container {
   height: 40px;
   flex-wrap: nowrap;
   margin-top: 16px;
-  margin-bottom: 8px;
   flex-shrink: 0;
 }
 div[data-type='memos_view'] .section-header-container > .title-text,
@@ -4059,7 +4048,6 @@ div[data-type='memos_view'] .memos-header-container > .btns-container {
   height: 40px;
   flex-wrap: nowrap;
   margin-top: 16px;
-  margin-bottom: 8px;
   flex-shrink: 0;
 }
 .theme-dark div[data-type='memos_view'] .section-header-container > .title-text,
@@ -4472,7 +4460,6 @@ div[data-type='memos_view'] .memos-header-container {
   height: 40px;
   flex-wrap: nowrap;
   margin-top: 16px;
-  margin-bottom: 8px;
   flex-shrink: 0;
 }
 div[data-type='memos_view'] .section-header-container > .title-text,
@@ -4553,7 +4540,6 @@ div[data-type='memos_view'] .memos-header-container > .btns-container {
   height: 40px;
   flex-wrap: nowrap;
   margin-top: 16px;
-  margin-bottom: 8px;
   flex-shrink: 0;
 }
 .theme-dark div[data-type='memos_view'] .section-header-container > .title-text,
@@ -7892,6 +7878,7 @@ div[data-type='memos_view'] #page-wrapper > .content-wrapper {
   padding-left: 10px;
   width: 600px;
   height: 100%;
+  gap: 8px;
 }
 div[data-type='memos_view'] #page-wrapper > .content-wrapper-padding-fix {
   display: flex;
@@ -7904,6 +7891,7 @@ div[data-type='memos_view'] #page-wrapper > .content-wrapper-padding-fix {
   height: 100%;
   overflow-y: hidden;
   padding-left: 34px;
+  gap: 8px;
 }
 @media only screen and (max-width: 875px) {
   div[data-type='memos_view'] body.mobile-show-sidebar #page-wrapper > .content-wrapper {


### PR DESCRIPTION
## Issue: Query Filter Spacing

With my latest pull request to fix the memo editor bottom margin I didn't take into account the spacing of the filter tag (my bad), when present, as you can see in the image below:

![filter-gap](https://user-images.githubusercontent.com/69484045/151658387-0f06ad8e-14ca-4e33-af92-d6587f4c99a6.png)

## Solution

- Inverted the padding-top (12px &rarr; 4px) & bottom (4px &rarr; 12px) values for both the Dark & Light Themes;
- There are some more changes on the code, but they're essentially code spacing alterations introduced by prettier;
