### PR TITLE
Fix (Mobile): Remove Memos Editor Right Margin

### DIFF
--- a/src/less/memo-editor.less
+++ b/src/less/memo-editor.less
@@ -40,7 +40,7 @@
   .theme-light div[data-type='memos_view'] .memo-editor-wrapper {
     width: calc(100% - 24px);
     margin: auto;
-    margin-right: 16px;
+
     // margin-bottom: 8px;
   }
 
@@ -91,7 +91,6 @@
   .theme-dark div[data-type='memos_view'] .memo-editor-wrapper {
     width: calc(100% - 24px);
     margin: auto;
-    margin-right: 16px;
     // margin-bottom: 8px;
   }
 


### PR DESCRIPTION
# Issue: Editor Right Margin

![editorMarginRight](https://user-images.githubusercontent.com/69484045/153484493-7eb93479-89dc-4649-a041-e28f6c7bbc5d.png)

On the mobile version of Memos, the Memos Editor right margin seems to be a bit off.
The current media query adds a right margin to the editor and the slight misalignment is solved by simply removing it.
I tested the plugin (some videos below) trying to see if it affected something else (even when pinned it worked fine), and couldn't find anything.

I hope I'm not missing anything!

Kind regards

# Changes
- **'memo-editor'** Removed 'margin-right: 16px' from '@media only screen and (max-width: 875px)' for both the Dark & Light themes;

# Editor Top
https://user-images.githubusercontent.com/69484045/153484830-5c54256b-58a4-49c3-a6b9-ed803dc0f124.mp4

# Editor Bottom
https://user-images.githubusercontent.com/69484045/153484851-e9836687-a4b0-4943-ad89-835cc7ed1a7b.mp4

# Editor Float
https://user-images.githubusercontent.com/69484045/153484881-4cd2903a-6480-4979-89ae-d4ae129419e2.mp4


