### PR TITLE
fix: 移除 reg lastIndex 的影响

### DIFF
--- a/src/components/ShareMemoImageDialog.tsx
+++ b/src/components/ShareMemoImageDialog.tsx
@@ -142,17 +142,17 @@ const ShareMemoImageDialog: React.FC<Props> = (props: Props) => {
   const internalImageUrls = [];
   let allMarkdownLink: string | any[] = [];
   let allInternalLink = [] as any[];
-  if (IMAGE_URL_REG.test(memo.content)) {
+  if (new RegExp(IMAGE_URL_REG).test(memo.content)) {
     let allExternalImageUrls = [] as string[];
     const anotherExternalImageUrls = [] as string[];
-    if (MARKDOWN_URL_REG.test(memo.content)) {
+    if (new RegExp(MARKDOWN_URL_REG).test(memo.content)) {
       allMarkdownLink = Array.from(memo.content.match(MARKDOWN_URL_REG));
     }
-    if (WIKI_IMAGE_URL_REG.test(memo.content)) {
+    if (new RegExp(WIKI_IMAGE_URL_REG).test(memo.content)) {
       allInternalLink = Array.from(memo.content.match(WIKI_IMAGE_URL_REG));
     }
     // const allInternalLink = Array.from(memo.content.match(WIKI_IMAGE_URL_REG));
-    if (MARKDOWN_WEB_URL_REG.test(memo.content)) {
+    if (new RegExp(MARKDOWN_WEB_URL_REG).test(memo.content)) {
       allExternalImageUrls = Array.from(memo.content.match(MARKDOWN_WEB_URL_REG));
     }
     if (allInternalLink.length) {


### PR DESCRIPTION
当使用 字面量 + g 的形式声明正则时，每次 test 字符串的时候会记录 lastIndex，导致 出现意料之外的结果。
例如:

```typescript
const IMAGE_URL_REG = /([^\s<\\*>']+\.(jpeg|jpg|gif|png|svg))(\]\])?(\))?/g;

IMAGE_URL_REG.test('![[Pasted Image 20220420133518.png]]<br>我的生活')
// result: true, lastIndex: 36

IMAGE_URL_REG.test('![[Pasted Image 20220420133518.png]]<br>我的生活')
// result: false, lastIndex:0
```

通过 new RegExp 移除 lastIndex 的影响