### PR TITLE
Fix: font-family doesn't support languages other than English/Chinese.

### DIFF
--- a/src/less/global.less
+++ b/src/less/global.less
@@ -23,7 +23,7 @@
 }
 
 div[data-type='memos_view']  {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Noto Sans", "Noto Sans CJK SC", "Microsoft YaHei UI", "Microsoft YaHei",
+  font-family: var(--font-interface), -apple-system, BlinkMacSystemFont, "PingFang SC", "Noto Sans", "Noto Sans CJK SC", "Microsoft YaHei UI", "Microsoft YaHei",
   "WenQuanYi Micro Hei", sans-serif, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
   "Noto Color Emoji";
   /*text-align: var();*/


### PR DESCRIPTION
`global.less`'s font-family is optimized for English/Chinese. Therefore, other languages render fonts poorly. Especially Japanese isn't good, because "Microsoft YaHei" has some Japanese characters.

I fixed font-family to use var(--font-interface), a CSS variable provided by obsidian. Interface fonts will be configurable in obsidian's settings due to this.